### PR TITLE
Fix `crypto_spec.rb`.

### DIFF
--- a/spec/crypto_spec.rb
+++ b/spec/crypto_spec.rb
@@ -10,12 +10,12 @@ describe 'Test card info encryption' do
 
   describe 'Using Caeser cipher' do
     it 'should encrypt card information' do
-      enc = SubstitutionCipher::Caeser.encrypt(@cc, @key)
+      enc = SubstitutionCipher::Caeser.encrypt(@cc.to_s, @key)
       enc.wont_equal @cc.to_s
     end
 
     it 'should decrypt text' do
-      enc = SubstitutionCipher::Caeser.encrypt(@cc, @key)
+      enc = SubstitutionCipher::Caeser.encrypt(@cc.to_s, @key)
       dec = SubstitutionCipher::Caeser.decrypt(enc, @key)
       dec.must_equal @cc.to_s
     end
@@ -23,12 +23,12 @@ describe 'Test card info encryption' do
 
   describe 'Using Permutation cipher' do
     it 'should encrypt card information' do
-      enc = SubstitutionCipher::Permutation.encrypt(@cc, @key)
+      enc = SubstitutionCipher::Permutation.encrypt(@cc.to_s, @key)
       enc.wont_equal @cc.to_s
     end
 
     it 'should decrypt text' do
-      enc = SubstitutionCipher::Permutation.encrypt(@cc, @key)
+      enc = SubstitutionCipher::Permutation.encrypt(@cc.to_s, @key)
       dec = SubstitutionCipher::Permutation.decrypt(enc, @key)
       dec.must_equal @cc.to_s
     end


### PR DESCRIPTION
Hi Soumya,

It's me again.
I got some error when I try to run `spec/crypto_spec.rb`:
```
1) Error:
Test card info encryption::Using Permutation cipher#test_0001_should encrypt card information:
NoMethodError: undefined method `chars' for #<CreditCard:SOME_HEX_ADDRESS>
    /path/to/hw_3-credit_card_crypto/substitution_cipher.rb:SOME_LINE_NUMBER:in `encrypt'
    spec/crypto_spec.rb:26:in `block (3 levels) in <main>'
```

And I found that the types of the arguments are wrong, the spec is passing `CreditCard` types while `encrypt` and `decrypt` are designed to be accepting `String` types.

That's why I created this PR.

Cheers,
Cheng-Yu